### PR TITLE
限制只能使用npm安装依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "这是webfunny的安装包",
   "main": "app.js",
   "scripts": {
+    "preinstall": "npx npm-client-limit npm",
     "bootstrap": "node config_bin_init.js",
     "slave": "node config_db_local.js && pm2 start config/slave.js && pm2 log slave",
     "reslave": "pm2 stop slave | pm2 delete slave | npm run slave",


### PR DESCRIPTION
由于package-lock.json对于非npm包管理器无效,所以依赖会安装其他版本的,导致项目无法启动